### PR TITLE
Ticket 5223: Fixed failing IOCs

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -306,6 +306,9 @@ print(const char* fmt, ...)
             return *this;
         }
         if (printed > -1) grow(len+printed);
+#if defined (_WIN32) && (_MSC_VER < 1700)
+		else if (printed == -1) grow(len + _vscprintf(fmt, va));
+#endif
         else grow(len);
     }
 }

--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -307,7 +307,11 @@ print(const char* fmt, ...)
         }
         if (printed > -1) grow(len+printed);
 #if defined (_WIN32) && (_MSC_VER < 1700)
-		else if (printed == -1) grow(len + _vscprintf(fmt, va));
+        else if (printed == -1) {
+            va_start(va, fmt);
+            grow(len + _vscprintf(fmt, va));
+            va_end(va);
+        }
 #endif
         else grow(len);
     }


### PR DESCRIPTION
See #5223 
In VS2010 the behaviour of `vsnprintf` was to return `-1` if there was not enough room in the buffer to print. In newer versions of VS and on linux the behaviour is to return how much you would have printed by if you could, even if the buffer is not long enough. The original code was only growing the buffer under the new behaviour, not the old. 