### PR TITLE
Fixed broken merge to reduce logging

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -306,6 +306,7 @@ print(const char* fmt, ...)
             return *this;
         }
         if (printed > -1) grow(len+printed);
+// Previous versions of VS return -1 on vsnprintf if the print is not possible.
 #if defined (_WIN32) && (_MSC_VER < 1700)
         else if (printed == -1) {
             va_start(va, fmt);

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -1172,7 +1172,7 @@ matchInput()
 	   @mismatch handler is installed and starts with 'in' (then we reparse the input).
 	   We have previously mismatched the same output (to limit repeating errors)
     */
-    bool printErrors = true; // (!(flags & AsyncMode) && onMismatch[0] != in && !inputLine.startswith(previousMismatch()));
+    bool printErrors = (!(flags & AsyncMode) && onMismatch[0] != in && !inputLine.startswith(previousMismatch()));
     char command;
     const char* fieldName = NULL;
     StreamBuffer formatstring;
@@ -1249,7 +1249,7 @@ normal_format:
                         }
                         else
                         {
-                            if (!(flags & AsyncMode) && onMismatch[0] != in)
+                            if (printErrors)
                             {
                                 error("%s: Input \"%s%s\" does not match format \"%%%s\"\n",
                                     name(), inputLine.expand(consumedInput, 20)(),


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/296 as well.

To test:
* Run the CCD100 tests on master, confirm they are broken
* Build this and the other test above
* Run the tests and confirm they work

This originated from a slightly incorrect merge when we updated StreamDevice.