### PR TITLE
Update to 2 8 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,26 @@
+##########################################################################
+# This is an EPICS Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 TOP = ..
 ifneq ($(wildcard ../configure),)
   # We are in an EPICS R3.14+ <TOP> location

--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ and the replies it sends.
 
 For a full documentation see
 https://paulscherrerinstitute.github.io/StreamDevice.
+
+## Licensing
+
+StreamDevice is free software: You can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+StreamDevice is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with StreamDevice. If not, see https://www.gnu.org/licenses/.

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,3 +1,26 @@
+##########################################################################
+# This is an EPICS Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 TOP=..
 include $(TOP)/config/CONFIG_APP
 ifneq ($(wildcard $(EPICS_BASE)/config),)

--- a/docs/protocol.html
+++ b/docs/protocol.html
@@ -482,12 +482,63 @@ To make this easier, <em>protocol arguments</em> can be used:
 move { out "\$1 GOTO %d"; }
 </pre>
 <p>
-Now, the protocol can be references in the <code>OUT</code> link
+Now the same protocol can be used in the <code>OUT</code> link
 of three different records as <code>move(X)</code>,
 <code>move(Y)</code> and <code>move(Z)</code>.
-Up to 9 parameters, referenced as <code>$1</code> ... <code>$9</code>
-can be specified in parentheses, separated by comma.
-The variable <code>$0</code> is replaced by the name of the protocol.
+</p>
+<p>
+Up to 9 parameters can be specified in parentheses, separated by comma.
+In the protocol, they are referenced as <code>$1</code> ...
+<code>$9</code> outside quotes or <code>\$1</code> ... <code>\$9</code>
+within quotes. The parameter <code>$0</code> resolves to the protocol name.
+</p>
+<div class="new">
+<p>
+To make links more readable, one space is allowed before and after each comma
+and the enclosing parentheses. This space is not part of the parameter string.
+Any additional space is part of the parameter.
+</p>
+<p>
+If a parameter contains matching pairs of parentheses, these and all commas
+inside are part of the parameter.
+This allows to pass parameter strings like <code>(1,2)</code> easily without
+much escaping.
+</p>
+<p>
+Unmatched parentheses must be escaped with double backslash <code>\\</code>
+as well as must be commas outside pairs of parentheses.
+Double backslash is necessary because one backslash is already consumed by
+the db file parser.
+To pass a literal backslash in a parameter string use 4 backslashes
+<code>\\\\</code>.
+</p>
+</div>
+<p>
+Note that macros can be used in parameters. That makes it possible to
+pass part of the record name to the protocol to be used in
+<a href="formats.html#redirection">redirections</a>.
+</p>
+
+<h4>Example:</h3>
+<pre>
+record(ai, "$(PREFIX)recX5") {
+    field(DTYP, "stream")
+    field(INP,  "@$(PROTOCOLFILE) read(5, X\\,Y $(PREFIX)) $(PORT)")
+}
+record(ai, "$(PREFIX)recY5") {}
+
+read { out 0x8$1 "READ \$2"; in "%f,%(\$3recY\$1)f" }
+</pre>
+<p>
+The protocol resolves to:
+</p>
+<pre>
+read { out 0x85 "READ X,Y"; in "%f,%($(PREFIX)recY5)f" }
+</pre>
+<p>
+Here <code>$(PREFIX)</code> is replaced with its macro value.
+But be aware that the macro is actually replaced before the link is parsed so
+that macro values containing comma or parentheses may have unintended effects.
 </p>
 
 <a name="usrvar"></a>
@@ -565,7 +616,7 @@ There is a fixed set of exception handler names starting with
   
  </dd>
 </dl>
-<h3>Example:</h3>
+<h4>Example:</h3>
 <pre>
 setPosition {
     out "POS %f";

--- a/src/AsynDriverInterface.cc
+++ b/src/AsynDriverInterface.cc
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to asyn driver for StreamDevice.       *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the interface to asyn driver for StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifdef EPICS_3_13
 #include <assert.h>

--- a/src/BCDConverter.cc
+++ b/src/BCDConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the BCD format converter of StreamDevice.            *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the BCD format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/BinaryConverter.cc
+++ b/src/BinaryConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the binary format converter of StreamDevice.         *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the binary format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <ctype.h>
 #include <limits.h>

--- a/src/CONFIG_STREAM
+++ b/src/CONFIG_STREAM
@@ -1,3 +1,24 @@
+##########################################################################
+# This is the build configuration file of StreamDevice.
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 # You may add more record interfaces
 # This requires the naming conventions
 # dev$(RECORDTYPE)Stream.c

--- a/src/ChecksumConverter.cc
+++ b/src/ChecksumConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2006-2018 Dirk Zimoch (dirk.zimoch@psi.ch)               *
-*                                                              *
-* This is the checksum pseudo-converter of StreamDevice.       *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the checksum pseudo-converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2006,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/DebugInterface.cc
+++ b/src/DebugInterface.cc
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to a debug and example bus drivers for *
-* StreamDevice. Please refer to the HTML files in ../doc/ for  *
-* a detailed documentation.                                    *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is a debug and example bus interface for StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamBusInterface.h"
 #include "StreamError.h"

--- a/src/DummyInterface.cc
+++ b/src/DummyInterface.cc
@@ -1,20 +1,25 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2011 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to a "dummy" bus driver for            *
-* StreamDevice. It does not provide any I/O functionality.     *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is a debug and example bus interface for StreamDevice.
+* It does not provide any I/O functionality.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamBusInterface.h"
 #include "StreamError.h"

--- a/src/EnumConverter.cc
+++ b/src/EnumConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the enum format converter of StreamDevice.           *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the enum format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"
@@ -127,7 +129,7 @@ printLong(const StreamFormat& fmt, StreamBuffer& output, long value)
     if (numEnums < 0) numEnums=-numEnums-1;
     while (numEnums-- && (value != index))
     {
-        while(*s)
+        while (*s)
         {
             if (*s == esc) s++;
             s++;
@@ -140,7 +142,7 @@ printLong(const StreamFormat& fmt, StreamBuffer& output, long value)
         error("Value %li not found in enum set\n", value);
         return false;
     }
-    while(*s)
+    while (*s)
     {
         if (*s == esc) s++;
         output.append(*s++);
@@ -165,7 +167,7 @@ scanLong(const StreamFormat& fmt, const char* input, long& value)
         debug("EnumConverter::scanLong: check #%ld \"%s\"\n", index, s);
         consumed = 0;
         match = true;
-        while(*s)
+        while (*s)
         {
             if (*s == StreamProtocolParser::skip)
             {

--- a/src/MacroMagic.h
+++ b/src/MacroMagic.h
@@ -1,3 +1,25 @@
+/*************************************************************************
+* This header provides macros for enum to string conversions.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
+
 #ifndef _MacroMagic_h
 #define _MacroMagic_h
 
@@ -28,7 +50,7 @@
 
 #define ENUM(type, args...) \
 enum type { args }; \
-static inline const char* type##ToStr(int x) {switch(x){MACRO_FOR_EACH(_CASE_LINE,args)default: return "invalid";}}\
+static inline const char* type##ToStr(int x) {switch(x) {MACRO_FOR_EACH(_CASE_LINE,args)default: return "invalid";}}\
 _ENUM_CAST(type)
 
 #else
@@ -65,7 +87,7 @@ _ENUM_CAST(type)
 
 #define ENUM(type,...) \
 enum type { __VA_ARGS__ }; \
-static inline const char* type##ToStr(int x) {switch(x){_EXPAND(MACRO_FOR_EACH(_CASE_LINE,__VA_ARGS__)) default: return "invalid";}} \
+static inline const char* type##ToStr(int x) {switch(x) {_EXPAND(MACRO_FOR_EACH(_CASE_LINE,__VA_ARGS__)) default: return "invalid";}} \
 _ENUM_CAST(type)
 #endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,22 +1,25 @@
-################################################################
-# StreamDevice Support                                         #
-#                                                              #
-# (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          #
-# (C) 2007 Dirk Zimoch (dirk.zimoch@psi.ch)                    #
-#                                                              #
-# This is the EPICS 3.14 Makefile of StreamDevice.             #
-# Normally it should not be necessary to modify this file.     #
-# All configuration can be done in CONFIG_STREAM               #
-#                                                              #
-# If you do any changes in this file, you are not allowed to   #
-# redistribute it any more. If there is a bug or a missing     #
-# feature, send me an email and/or your patch. If I accept     #
-# your changes, they will go to the next release.              #
-#                                                              #
-# DISCLAIMER: If this software breaks something or harms       #
-# someone, it's your problem.                                  #
-#                                                              #
-################################################################
+##########################################################################
+# This is the EPICS 3.14+ Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
 
 TOP = ../..
 ifneq ($(wildcard ../../configure),)

--- a/src/Makefile.Host
+++ b/src/Makefile.Host
@@ -1,22 +1,25 @@
-################################################################
-# StreamDevice Support                                         #
-#                                                              #
-# (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          #
-# (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)                    #
-#                                                              #
-# This is the EPICS 3.13 Makefile of StreamDevice.             #
-# Normally it should not be necessary to modify this file.     #
-# All configuration can be done in CONFIG_STREAM               #
-#                                                              #
-# If you do any changes in this file, you are not allowed to   #
-# redistribute it any more. If there is a bug or a missing     #
-# feature, send me an email and/or your patch. If I accept     #
-# your changes, they will go to the next release.              #
-#                                                              #
-# DISCLAIMER: If this software breaks something or harms       #
-# someone, it's your problem.                                  #
-#                                                              #
-################################################################
+##########################################################################
+# This is an EPICS 3.13 Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
 
 TOP = ../..
 ifneq ($(wildcard ../../../config),)

--- a/src/Makefile.Vx
+++ b/src/Makefile.Vx
@@ -1,22 +1,25 @@
-################################################################
-# StreamDevice Support                                         #
-#                                                              #
-# (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          #
-# (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)                    #
-#                                                              #
-# This is the EPICS 3.13 Makefile of StreamDevice.             #
-# Normally it should not be necessary to modify this file.     #
-# All configuration can be done in CONFIG_STREAM               #
-#                                                              #
-# If you do any changes in this file, you are not allowed to   #
-# redistribute it any more. If there is a bug or a missing     #
-# feature, send me an email and/or your patch. If I accept     #
-# your changes, they will go to the next release.              #
-#                                                              #
-# DISCLAIMER: If this software breaks something or harms       #
-# someone, it's your problem.                                  #
-#                                                              #
-################################################################
+##########################################################################
+# This is an EPICS 3.13 Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
 
 TOP = ../..
 ifneq ($(wildcard ../../../config),)

--- a/src/MantissaExponentConverter.cc
+++ b/src/MantissaExponentConverter.cc
@@ -1,24 +1,26 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2008 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is a custom exponential format converter for            *
-* StreamDevice.                                                *
-* The number is represented as two signed integers, mantissa   *
-* and exponent, like in +00011-01                              *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is a custom exponential format converter for StreamDevice.
+* A number is represented as two signed integers, mantissa and exponent,
+* like in "+00011-01" (without an "E")
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2008 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/RawConverter.cc
+++ b/src/RawConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the raw format converter of StreamDevice.            *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the raw integer format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/RawFloatConverter.cc
+++ b/src/RawFloatConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the raw format converter of StreamDevice.            *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the raw floating point format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/RegexpConverter.cc
+++ b/src/RegexpConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2007 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the regexp format converter of StreamDevice.         *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the regular expression format converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2007 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamBuffer                                                 *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is a buffer class used in StreamDevice for I/O.         *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is a buffer class used in StreamDevice for I/O.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 // Make sure that vsnprintf is available
 #ifndef _BSD_SOURCE
@@ -306,15 +309,7 @@ print(const char* fmt, ...)
             return *this;
         }
         if (printed > -1) grow(len+printed);
-// Previous versions of VS return -1 on vsnprintf if the print is not possible.
-#if defined (_WIN32) && (_MSC_VER < 1700)
-        else if (printed == -1) {
-            va_start(va, fmt);
-            grow(len + _vscprintf(fmt, va));
-            va_end(va);
-        }
-#endif
-        else grow(len);
+        else grow(cap*2-1);
     }
 }
 

--- a/src/StreamBuffer.h
+++ b/src/StreamBuffer.h
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamBuffer                                                 *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is a buffer class used in StreamDevice for I/O.         *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is a buffer class used in StreamDevice for I/O.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamBuffer_h
 #define StreamBuffer_h
@@ -199,11 +202,10 @@ public:
 
     // find: get index of data in buffer or -1
     ssize_t find(char c, ssize_t start=0) const
-        {char* p;
+        {if (start < 0 && (start -= len) < 0) start = 0;
+         char* p;
          return (p = static_cast<char*>(
-            memchr(buffer+offs+(start<0?start+len:start),
-                c, start<0?-start:len-start)))?
-            p-(buffer+offs) : -1;}
+            memchr(buffer+offs+start, c, len-start)))? p-(buffer+offs) : -1;}
 
     ssize_t find(const void* s, size_t size, ssize_t start=0) const;
 

--- a/src/StreamBusInterface.cc
+++ b/src/StreamBusInterface.cc
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to bus drivers for StreamDevice.       *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the interface to bus (I/O) drivers for StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <stdio.h>
 #include "StreamBusInterface.h"

--- a/src/StreamBusInterface.h
+++ b/src/StreamBusInterface.h
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to bus drivers for StreamDevice.       *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the interface to bus (I/O) drivers for StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamBusInterface_h
 #define StreamBusInterface_h

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the kernel of StreamDevice.                          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the core of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamCore.h"
 #include "StreamError.h"
@@ -34,7 +36,7 @@ printCommands(StreamBuffer& buffer, const char* c)
     unsigned long eventnumber;
     while (1)
     {
-        switch(*c++)
+        switch (*c++)
         {
             case end:
                 return buffer();
@@ -189,14 +191,26 @@ parse(const char* filename, const char* _protocolname)
     ssize_t i = protocolname.find('(');
     if (i >= 0)
     {
-        while (i >= 0)
+        while (i < (ssize_t)protocolname.length())
         {
             if (protocolname[i-1] == ' ')
                 protocolname.remove(--i, 1); // remove trailing space
-            protocolname[i] = '\0'; // replace '(' and ',' with '\0'
+            protocolname[i] = '\0'; // replace initial '(' and separating ',' with '\0'
             if (protocolname[i+1] == ' ')
                 protocolname.remove(i+1, 1); // remove leading space
-            i = protocolname.find(',', i+1);
+            int brackets = 0;
+            do {
+                i++;
+                i += strcspn(protocolname(i), ",()\\");
+                char c = protocolname[i];
+                if (c == '(') brackets++;
+                else if (c == ')') brackets--;
+                else if (c == ',' && brackets <= 0) break;
+                else if (c == '\\') {
+                    if (protocolname[i+1] == '\\') i++; // keep '\\'
+                    else protocolname.remove(i, 1); // else skip over next char
+                }
+            } while (i < (ssize_t)protocolname.length());
         }
         // should have closing parentheses
         if (protocolname[-1] != ')')
@@ -206,9 +220,8 @@ parse(const char* filename, const char* _protocolname)
         }
         protocolname.truncate(-1); // remove ')'
         if (protocolname[-1] == ' ')
-        {
             protocolname.truncate(-1); // remove trailing space
-        }
+        debug("StreamCore::parse \"%s\" -> \"%s\"\n", _protocolname, protocolname.expand()());
     }
     StreamProtocolParser::Protocol* protocol;
     protocol = StreamProtocolParser::getProtocol(filename, protocolname);
@@ -975,8 +988,8 @@ readCallback(StreamIoStatus status,
                 evalIn();
                 return 0;
             }
-            debug("StreamCore::readCallback(%s): No reply from device within %ld ms\n",
-                name(), replyTimeout);
+            error("%s: No reply within %ld ms to \"%s\"\n",
+                name(), replyTimeout, outputLine.expand()());
             inputBuffer.clear();
             finishProtocol(ReplyTimeout);
             return 0;
@@ -1361,7 +1374,7 @@ normal_format:
                     {
                         int i = 0;
                         while (commandIndex[i] >= ' ') i++;
-                        error("%s: Input \"%s%s%s\"\n", 
+                        error("%s: Input \"%s%s%s\"\n",
                             name(),
                             consumedInput > 20 ? "..." : "",
                             inputLine.expand(consumedInput > 20 ? consumedInput-20 : 0, 40)(),
@@ -1374,7 +1387,7 @@ normal_format:
                             consumedInput > 10 ? "..." : "",
                             inputLine.expand(consumedInput > 10 ? consumedInput-10 : 0,
                                 consumedInput > 10 ? 10 : consumedInput)());
-                        
+
                         error("%s: got \"%s%s\" where \"%s\" was expected\n",
                             name(),
                             inputLine.expand(consumedInput, 10)(),
@@ -1805,6 +1818,24 @@ printStatus(StreamBuffer& buffer)
     if (flags & WaitPending)      buffer.append(" WaitPending");
     if (flags & Aborted)          buffer.append(" Aborted");
     busPrintStatus(buffer);
+}
+
+const char* StreamCore::
+license(void)
+{
+    return
+        "StreamDevice is free software: You can redistribute it and/or modify\n"
+        "it under the terms of the GNU Lesser General Public License as published\n"
+        "by the Free Software Foundation, either version 3 of the License, or\n"
+        "(at your option) any later version.\n"
+        "\n"
+        "StreamDevice is distributed in the hope that it will be useful,\n"
+        "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+        "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the\n"
+        "GNU Lesser General Public License for more details\n"
+        "\n"
+        "You should have received a copy of the GNU Lesser General Public License\n"
+        "along with StreamDevice. If not, see https://www.gnu.org/licenses/.\n";
 }
 
 #include "streamReferences"

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the kernel of StreamDevice.                          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the core of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamCore_h
 #define StreamCore_h
@@ -228,7 +230,8 @@ public:
     void printProtocol(FILE* = stdout);
     const char* name() { return streamname; }
     void printStatus(StreamBuffer& buffer);
-    
+    static const char* license(void);
+
 private:
     char* printCommands(StreamBuffer& buffer, const char* c);
 };

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the interface to EPICS for StreamDevice.             *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface to EPICS.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <errno.h>
 #include "StreamCore.h"
@@ -29,6 +31,9 @@
 
 #ifdef EPICS_3_13
 extern "C" {
+
+static char* epicsStrDup(const char *s) { char* c = (char*)malloc(strlen(s)+1); strcpy(c, s); return c; }
+
 #endif
 
 #define epicsAlarmGLOBAL
@@ -161,10 +166,7 @@ class Stream : protected StreamCore
     Stream(dbCommon* record, const struct link *ioLink,
         streamIoFunction readData, streamIoFunction writeData);
     ~Stream();
-    long parseLink(const struct link *ioLink, char* filename, char* protocol,
-        char* busname, int* addr, char* busparam);
-    long initRecord(const char* filename, const char* protocol,
-        const char* busname, int addr, const char* busparam);
+    long initRecord(char* linkstring);
     bool print(format_t *format, va_list ap);
     ssize_t scan(format_t *format, void* pvalue, size_t maxStringSize);
     bool process();
@@ -211,7 +213,7 @@ long streamReload(const char* recordname)
     int oldStreamError = streamError;
     streamError = 1;
 
-    if(!pdbbase) {
+    if (!pdbbase) {
         error("No database has been loaded\n");
         streamError = oldStreamError;
         return ERROR;
@@ -223,7 +225,7 @@ long streamReload(const char* recordname)
         if (recordname && recordname[0] &&
 #ifdef EPICS_3_13
             strcmp(stream->name(), recordname) == 0)
-#else        
+#else
             !epicsStrGlobMatch(stream->name(), recordname))
 #endif
             continue;
@@ -355,6 +357,13 @@ report(int interest)
 {
     debug("Stream::report(interest=%d)\n", interest);
     printf("  %s\n", StreamVersion);
+    printf("  (C) 1999 Dirk Zimoch (dirk.zimoch@psi.ch)\n");
+    if (interest == 100)
+    {
+        printf("\n%s", license());
+        return OK;
+    }
+    printf("  Use interest level 100 for license information\n");
 
     printf("  registered bus interfaces:\n");
     StreamBusInterfaceClass interface;
@@ -365,6 +374,7 @@ report(int interest)
     }
 
     if (interest < 1) return OK;
+
     printf("  registered converters:\n");
     StreamFormatConverter* converter;
     int c;
@@ -534,12 +544,7 @@ long streamInitRecord(dbCommon* record, const struct link *ioLink,
     streamIoFunction readData, streamIoFunction writeData)
 {
     long status;
-    char filename[256];
-    char protocol[256];
-    char busname[256];
-    int addr = -1;
-    char busparam[256];
-    memset(busparam, 0 ,sizeof(busparam));
+    char* linkstring;
 
     debug("streamInitRecord(%s): SEVR=%d\n", record->name, record->sevr);
     Stream* stream = static_cast<Stream*>(record->dpvt);
@@ -556,19 +561,30 @@ long streamInitRecord(dbCommon* record, const struct link *ioLink,
             record->name);
         stream->finishProtocol(Stream::Abort);
     }
-    // scan the i/o link
-    debug("streamInitRecord(%s): parse link \"%s\"\n",
-        record->name, ioLink->value.instio.string);
-    status = stream->parseLink(ioLink, filename, protocol,
-        busname, &addr, busparam);
-    // (re)initialize bus and protocol
-    if (status == 0)
+    if (ioLink->type != INST_IO)
     {
-        debug("streamInitRecord(%s): calling initRecord\n",
-            record->name);
-        status = stream->initRecord(filename, protocol,
-            busname, addr, busparam);
+        error("%s: Wrong I/O link type %s\n", record->name,
+            pamaplinkType[ioLink->type].strvalue);
+        return S_dev_badInitRet;
     }
+    if (!ioLink->value.instio.string[0])
+    {
+        error("%s: Empty I/O link. "
+            "Forgot the leading '@' or confused INP with OUT or link is too long ?\n",
+            record->name);
+        return S_dev_badInitRet;
+    }
+    // (re)initialize bus and protocol
+    linkstring = epicsStrDup(ioLink->value.instio.string);
+    if (!linkstring)
+    {
+        error("%s: Out of memory", record->name);
+        return S_dev_noMemory;
+    }
+    debug("streamInitRecord(%s): calling initRecord\n",
+        record->name);
+    status = stream->initRecord(linkstring);
+    free(linkstring);
     if (status != OK && status != DO_NOT_CONVERT)
     {
         error("%s: Record initialization failed\n", record->name);
@@ -698,77 +714,77 @@ Stream::
 }
 
 long Stream::
-parseLink(const struct link *ioLink, char* filename,
-    char* protocol, char* busname, int* addr, char* busparam)
+initRecord(char* linkstring /* modifiable copy */)
 {
-    // parse link parameters: filename protocol busname addr busparam
-    int n1, n2;
-    if (ioLink->type != INST_IO)
-    {
-        error("%s: Wrong I/O link type %s\n", name(),
-            pamaplinkType[ioLink->type].strvalue);
-        return S_dev_badInitRet;
-    }
-    if (0 >= sscanf(ioLink->value.instio.string, "%s%n", filename, &n1))
-    {
-        error("%s: Empty I/O link. "
-            "Forgot the leading '@' or confused INP with OUT or link is too long ?\n",
-            name());
-        return S_dev_badInitRet;
-    }
-    if (0 >= sscanf(ioLink->value.instio.string+n1, " %[^ \t(] %n", protocol, &n2))
-    {
-        error("%s: Missing protocol name\n"
-            "  expect \"@file protocol[(arg1,...)] bus [addr] [params]\"\n"
-            "  in \"@%s\"\n", name(),
-            ioLink->value.instio.string);
-        return S_dev_badInitRet;
-    }
-    n1+=n2;
-    if (ioLink->value.instio.string[n1] == '(')
-    {
-        n2 = 0;
-        sscanf(ioLink->value.instio.string+n1, " %[^)] %n", protocol+strlen(protocol), &n2);
-        n1+=n2;
-        if (ioLink->value.instio.string[n1++] != ')')
-        {
-            error("%s: Missing ')' after protocol arguments '%s'\n"
-                "  expect \"@file protocol(arg1,...) bus [addr] [params]\"\n"
-                "  in \"@%s\"\n", name(), protocol,
-                ioLink->value.instio.string);
-            return S_dev_badInitRet;
-        }
-        strcat(protocol, ")");
-    }
-    if (0 >= sscanf(ioLink->value.instio.string+n1, "%s %i %99c", busname, addr, busparam))
-    {
-        error("%s: Missing bus name\n"
-            "  expect \"@file protocol[(arg1,...)] bus [addr] [params]\"\n"
-            "  in \"@%s\"\n", name(),
-            ioLink->value.instio.string);
-        return S_dev_badInitRet;
-    }    
-    return OK;
-}
+    char *filename;
+    char *protocol;
+    char *busname;
+    char *busparam;
+    long addr = -1;
 
-long Stream::
-initRecord(const char* filename, const char* protocol,
-    const char* busname, int addr, const char* busparam)
-{
-    // It is safe to call this function again with different arguments
+    debug("Stream::initRecord %s: parse link string \"%s\"\n", name(), linkstring);
+
+    while (isspace(*linkstring)) linkstring++;
+    filename = linkstring;
+    while (*linkstring && !isspace(*linkstring)) linkstring++;
+    if (*linkstring) *linkstring++ = 0;
+
+    while (isspace(*linkstring)) linkstring++;
+    protocol = linkstring;
+    while (*linkstring && !isspace(*linkstring) && *linkstring != '(') linkstring++;
+    while (isspace(*linkstring)) linkstring++;
+    if (*linkstring == '(') {
+        int brackets = 0;
+        while(*++linkstring) {
+            if (*linkstring == '(') brackets++;
+            else if (*linkstring == ')') brackets--;
+            else if (*linkstring == '\\' && !*++linkstring) break;
+            else if (isspace(*linkstring) && brackets < 0) break;
+        }
+    }
+    else if (*linkstring) linkstring--;
+    if (*linkstring) *linkstring++ = 0;
+
+    while (isspace(*linkstring)) linkstring++;
+    busname = linkstring;
+    while (*linkstring && !isspace(*linkstring)) linkstring++;
+    if (*linkstring) *linkstring++ = 0;
+
+    if (linkstring) addr = strtol(linkstring, &linkstring, 0);
+    while (isspace(*linkstring)) linkstring++;
+    busparam = linkstring;
+
+    debug("Stream::initRecord %s: filename=\"%s\" protocol=\"%s\" bus=\"%s\" addr=%ld params=\"%s\"\n",
+        name(), filename, protocol, busname, addr, busparam);
+
+    if (!*filename)
+    {
+        error("%s: Missing protocol file name\n", name());
+        return S_dev_badInitRet;
+    }
+    if (!*protocol)
+    {
+        error("%s: Missing protocol name\n", name());
+        return S_dev_badInitRet;
+    }
+    if (!*busname)
+    {
+        error("%s: Missing bus name\n", name());
+        return S_dev_badInitRet;
+    }
 
     // attach to bus interface
-    debug("Stream::initRecord %s: attachBus(%s, %d, \"%s\")\n",
+    debug("Stream::initRecord %s: attachBus(\"%s\", %ld, \"%s\")\n",
         name(), busname, addr, busparam);
     if (!attachBus(busname, addr, busparam))
     {
-        error("%s: Can't attach to bus %s %d\n",
+        error("%s: Can't attach to bus %s %ld\n",
             name(), busname, addr);
         return S_dev_noDevice;
     }
 
     // parse protocol file
-    debug("Stream::initRecord %s: parse(%s, %s)\n",
+    debug("Stream::initRecord %s: parse(\"%s\", \"%s\")\n",
         name(), filename, protocol);
     if (!parse(filename, protocol))
     {
@@ -871,7 +887,7 @@ process()
     if (!startProtocol(record->proc == 2 ? StreamCore::StartInit : StreamCore::StartNormal))
     {
         debug("Stream::process(%s): could not start %sprotocol, status=%s (%d)\n",
-            name(), record->proc == 2 ? "@init " : "", 
+            name(), record->proc == 2 ? "@init " : "",
                 status >= 0 && status < ALARM_NSTATUS ?
                     epicsAlarmConditionStrings[status] : "ERROR",
             status);

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is error and debug message handling of StreamDevice.    *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is error and debug message handling of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamError.h"
 #ifdef _WIN32

--- a/src/StreamError.h
+++ b/src/StreamError.h
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is error and debug message handling of StreamDevice.    *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is error and debug message handling of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamError_h
 #define StreamError_h

--- a/src/StreamFormat.h
+++ b/src/StreamFormat.h
@@ -1,23 +1,25 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This header defines the format stucture used to interface    *
-* format converters and record interfaces to StreamDevice      *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This header defines the format stucture used to interface
+* format converters and EPICS records to StreamDevice
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamFormat_h
 #define StreamFormat_h

--- a/src/StreamFormatConverter.cc
+++ b/src/StreamFormatConverter.cc
@@ -1,23 +1,25 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the format converter base and includes the standard  *
-* format converters for StreamDevice.                          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the format converter base for StreamDevice.
+* It includes the standard converters as known from printf/scanf.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/StreamFormatConverter.h
+++ b/src/StreamFormatConverter.h
@@ -1,21 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the format converter header of StreamDevice.         *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the format converter header of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamFormatConverter_h
 #define StreamFormatConverter_h

--- a/src/StreamProtocol.cc
+++ b/src/StreamProtocol.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the protocol parser of StreamDevice.                 *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the protocol parser of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <ctype.h>
 #include <stdlib.h>
@@ -286,7 +288,7 @@ parseProtocol(Protocol& protocol, StreamBuffer* commands)
         }
         if (token[0] == '{')
         {
-            error(line, filename(), "Expect %s name before '%c'\n", 
+            error(line, filename(), "Expect %s name before '%c'\n",
                 isGlobalContext(commands) ? "protocol" : "handler",
                 token[0]);
             return false;
@@ -1039,7 +1041,7 @@ compileNumber(unsigned long& number, const char*& source, unsigned long max)
             *source, source);
         if (*source == '$')
         {
-            if(!replaceVariable(buffer, source)) return false;
+            if (!replaceVariable(buffer, source)) return false;
             debug("buffer=%s\n", buffer.expand()());
             buffer.truncate(-1-(int)sizeof(int));
         }

--- a/src/StreamProtocol.h
+++ b/src/StreamProtocol.h
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the protocol parser of StreamDevice.                 *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the protocol parser of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef StreamProtocol_h
 #define StreamProtocol_h

--- a/src/StreamVersion.c
+++ b/src/StreamVersion.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This provides a version string for StreamDevice.             *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This file provides a version string for StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "devStream.h"
 

--- a/src/TimestampConverter.cc
+++ b/src/TimestampConverter.cc
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the time stamp converter of StreamDevice.            *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the time stamp converter of StreamDevice.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "StreamFormatConverter.h"
 #include "StreamError.h"

--- a/src/devStream.h
+++ b/src/devStream.h
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is the header for the EPICS interface to StreamDevice.  *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the header for StreamDevice interfaces to EPICS.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #ifndef devStream_h
 #define devStream_h
@@ -28,6 +30,7 @@
 
 #define STREAM_MAJOR 2
 #define STREAM_MINOR 8
+#define STREAM_PATCHLEVEL 12
 
 #ifndef OK
 #define OK 0

--- a/src/devaaiStream.c
+++ b/src/devaaiStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for aai records                *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS aai records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2006 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "aaiRecord.h"
 #include "devStream.h"

--- a/src/devaaoStream.c
+++ b/src/devaaoStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for aao records                *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS aao records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2006 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include <stdio.h>
 #include "epicsString.h"

--- a/src/devaiStream.c
+++ b/src/devaiStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for analog input records       *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS ai records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "aiRecord.h"
 #include "devStream.h"

--- a/src/devaoStream.c
+++ b/src/devaoStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for analog output records     *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS ao records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "aoRecord.h"
 #include "menuConvert.h"

--- a/src/devbiStream.c
+++ b/src/devbiStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for binary input records      *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS bi records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "biRecord.h"
 #include "devStream.h"

--- a/src/devboStream.c
+++ b/src/devboStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for binary output records     *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS bo records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "boRecord.h"
 #include "devStream.h"

--- a/src/devcalcoutStream.c
+++ b/src/devcalcoutStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for calcout records           *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS calcout records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "calcoutRecord.h"
 #include "devStream.h"
@@ -46,7 +49,7 @@ static long readData(dbCommon *record, format_t *format)
             break;
         }
         default:
-            return ERROR;        
+            return ERROR;
     }
     if (record->pact) return OK;
     /* In @init handler, no processing, enforce monitor updates. */
@@ -60,10 +63,10 @@ static long readData(dbCommon *record, format_t *format)
         monitor_mask |= DBE_LOG;
         co->alst = co->val;
     }
-    if (monitor_mask){
+    if (monitor_mask) {
         db_post_events(record, &co->val, monitor_mask);
     }
-    
+
     return OK;
 }
 

--- a/src/devint64inStream.c
+++ b/src/devint64inStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for int64in records           *
-*                                                              *
-* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS int64in records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "int64inRecord.h"
 #include "devStream.h"

--- a/src/devint64outStream.c
+++ b/src/devint64outStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for int64out records          *
-*                                                              *
-* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS int64out records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "int64outRecord.h"
 #include "devStream.h"

--- a/src/devlonginStream.c
+++ b/src/devlonginStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for long input records        *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS longin records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "longinRecord.h"
 #include "devStream.h"

--- a/src/devlongoutStream.c
+++ b/src/devlongoutStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for long output records       *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS longout records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "longoutRecord.h"
 #include "devStream.h"

--- a/src/devlsiStream.c
+++ b/src/devlsiStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for long string in records    *
-*                                                              *
-* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS lsi records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "lsiRecord.h"
 #include "devStream.h"

--- a/src/devlsoStream.c
+++ b/src/devlsoStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for long string out records   *
-*                                                              *
-* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS lso records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "lsoRecord.h"
 #include "menuPost.h"

--- a/src/devmbbiDirectStream.c
+++ b/src/devmbbiDirectStream.c
@@ -1,23 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for                            *
-* multibit binary input direct records                         *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS mbbiDirect records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "mbbiDirectRecord.h"
 #include "devStream.h"

--- a/src/devmbbiStream.c
+++ b/src/devmbbiStream.c
@@ -1,23 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for                            *
-* multibit binary input records                                *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS mbbi records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "mbbiRecord.h"
 #include "devStream.h"

--- a/src/devmbboDirectStream.c
+++ b/src/devmbboDirectStream.c
@@ -1,23 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for                            *
-* multibit binary output direct records                        *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS mbboDirect records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "mbboDirectRecord.h"
 #include "devStream.h"

--- a/src/devmbboStream.c
+++ b/src/devmbboStream.c
@@ -1,23 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for                            *
-* multibit binary output records                               *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS mbbo records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "mbboRecord.h"
 #include "devStream.h"

--- a/src/devscalcoutStream.c
+++ b/src/devscalcoutStream.c
@@ -1,21 +1,24 @@
-/***************************************************************
-* Stream Device record interface for string calcout records    *
-*                                                              *
-* (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS scalcout records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 2006 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "sCalcoutRecord.h"
 #include "devStream.h"
@@ -25,7 +28,7 @@
    of the device support.
    Fix: sCalcoutRecord.c, end of init_record() add
 
-        if(pscalcoutDSET->init_record ) {
+        if (pscalcoutDSET->init_record ) {
             return (*pscalcoutDSET->init_record)(pcalc);
         }
 */

--- a/src/devstringinStream.c
+++ b/src/devstringinStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for string input records      *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS stringin records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "stringinRecord.h"
 #include "devStream.h"

--- a/src/devstringoutStream.c
+++ b/src/devstringoutStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* Stream Device record interface for string output records     *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS stringout records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "stringoutRecord.h"
 #include "devStream.h"

--- a/src/devwaveformStream.c
+++ b/src/devwaveformStream.c
@@ -1,22 +1,24 @@
-/***************************************************************
-* StreamDevice record interface for waveform records           *
-*                                                              *
-* (C) 1999 Dirk Zimoch (zimoch@delta.uni-dortmund.de)          *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an EPICS record Interface for StreamDevice.          *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/*************************************************************************
+* This is the StreamDevice interface for EPICS waveform records.
+* Please see ../docs/ for detailed documentation.
+*
+* (C) 1999,2005 Dirk Zimoch (dirk.zimoch@psi.ch)
+*
+* This file is part of StreamDevice.
+*
+* StreamDevice is free software: You can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* StreamDevice is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+*************************************************************************/
 
 #include "waveformRecord.h"
 #include "devStream.h"

--- a/src/makedbd.pl
+++ b/src/makedbd.pl
@@ -1,3 +1,25 @@
+##########################################################################
+# This is a helper script for StreamDevice.
+# It generates a file that registers StreamDevice interfaces with EPICS.
+#
+# (C) 2011 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 if (@ARGV[0] eq "--rec-only") {
     shift;
 } else {

--- a/src/makeref.pl
+++ b/src/makeref.pl
@@ -1,3 +1,25 @@
+##########################################################################
+# This is a helper script for StreamDevice.
+# It generates a file that makes sure all defined interfaces get linked.
+#
+# (C) 2011 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 $t=@ARGV[0];
 shift;
 for (@ARGV) {

--- a/streamApp/Makefile
+++ b/streamApp/Makefile
@@ -1,3 +1,26 @@
+##########################################################################
+# This is an EPICS 3.14+ Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 TOP = ../..
 ifneq ($(wildcard ../../configure),)
   include $(TOP)/configure/CONFIG

--- a/streamApp/Makefile.Host
+++ b/streamApp/Makefile.Host
@@ -1,3 +1,26 @@
+##########################################################################
+# This is an EPICS 3.13 Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 TOP = ../..
 ifneq ($(wildcard ../../../config),)
 TOP = ../../..

--- a/streamApp/Makefile.Vx
+++ b/streamApp/Makefile.Vx
@@ -1,3 +1,26 @@
+##########################################################################
+# This is an EPICS 3.13 Makefile for StreamDevice.
+# Normally it should not be necessary to modify this file.
+# All configuration can be done in CONFIG_STREAM
+#
+# (C) 2007,2018 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 TOP = ../..
 ifneq ($(wildcard ../../../config),)
 TOP = ../../..

--- a/streamApp/checksums.cmd
+++ b/streamApp/checksums.cmd
@@ -1,4 +1,25 @@
 #!/bin/sh
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 exec O.$EPICS_HOST_ARCH/streamApp $0
 dbLoadDatabase "O.Common/streamApp.dbd"
 streamApp_registerRecordDeviceDriver

--- a/streamApp/checksums.db
+++ b/streamApp/checksums.db
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS database for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 record (stringout, "DZ:checksums")
 {
     field (DTYP, "stream")

--- a/streamApp/checksums.proto
+++ b/streamApp/checksums.proto
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug protocol file for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 Terminator = NL;
 
 # Output string, checksum name and checksum value

--- a/streamApp/example-3-13.cmd
+++ b/streamApp/example-3-13.cmd
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 BIN="<library directory>"
 DBD="<dbd directory>"
 HOME="<ioc home direcory>"

--- a/streamApp/example.cmd
+++ b/streamApp/example.cmd
@@ -1,4 +1,25 @@
 #!/bin/sh
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 exec O.$EPICS_HOST_ARCH/streamApp $0
 dbLoadDatabase "O.Common/streamApp.dbd"
 streamApp_registerRecordDeviceDriver

--- a/streamApp/example.db
+++ b/streamApp/example.db
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS database for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 # process this record to reload all stream protocols
 record (sub, "$(PREFIX):reload")
 {

--- a/streamApp/example.proto
+++ b/streamApp/example.proto
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug protocol file for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 # example stream protocol file
 
 Terminator = CR LF;

--- a/streamApp/regexp.cmd
+++ b/streamApp/regexp.cmd
@@ -1,4 +1,25 @@
 #!/bin/sh
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 exec O.$EPICS_HOST_ARCH/streamApp $0
 dbLoadDatabase "O.Common/streamApp.dbd"
 streamApp_registerRecordDeviceDriver

--- a/streamApp/regexp.db
+++ b/streamApp/regexp.db
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS database for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 record (stringin, "DZ:regexp")
 {
     field (DTYP, "stream")

--- a/streamApp/regexp.proto
+++ b/streamApp/regexp.proto
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug protocol file for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 # regular expression example
 # extract the title of from a web page
 

--- a/streamApp/simple.cmd
+++ b/streamApp/simple.cmd
@@ -1,4 +1,25 @@
 #!/bin/sh
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 exec O.$EPICS_HOST_ARCH/streamApp $0
 dbLoadDatabase "O.Common/streamApp.dbd"
 streamApp_registerRecordDeviceDriver

--- a/streamApp/simple.db
+++ b/streamApp/simple.db
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS database for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 record (stringout, "$(P):cmd")
 {
     field (DTYP, "stream")

--- a/streamApp/simple.proto
+++ b/streamApp/simple.proto
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug protocol file for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 terminator = CR LF;
 
 cmd {

--- a/streamApp/streamAppMain.cc
+++ b/streamApp/streamAppMain.cc
@@ -1,21 +1,4 @@
-/***************************************************************
-* StreamDevice Support                                         *
-*                                                              *
-* (C) 2005 Dirk Zimoch (dirk.zimoch@psi.ch)                    *
-*                                                              *
-* This is an example application initializer for StreamDevice. *
-* Please refer to the HTML files in ../docs/ for a detailed    *
-* documentation.                                               *
-*                                                              *
-* If you do any changes in this file, you are not allowed to   *
-* redistribute it any more. If there is a bug or a missing     *
-* feature, send me an email and/or your patch. If I accept     *
-* your changes, they will go to the next release.              *
-*                                                              *
-* DISCLAIMER: If this software breaks something or harms       *
-* someone, it's your problem.                                  *
-*                                                              *
-***************************************************************/
+/* Author:  Marty Kraimer Date:    17MAR2000 */
 
 #include "epicsThread.h"
 #include "iocsh.h"

--- a/streamApp/terminal.tcl
+++ b/streamApp/terminal.tcl
@@ -1,4 +1,25 @@
 #!/usr/bin/env wish
+##########################################################################
+# This is a debug tool for StreamDevice.
+# It simulates a network device.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
 
 proc createTerm {sock} {
     global socket port

--- a/streamApp/test.cmd
+++ b/streamApp/test.cmd
@@ -1,4 +1,25 @@
 #!/bin/sh
+##########################################################################
+# This is an example and debug EPICS startup script for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 exec O.$EPICS_HOST_ARCH/streamApp $0
 dbLoadDatabase "O.Common/streamApp.dbd"
 streamApp_registerRecordDeviceDriver

--- a/streamApp/test.db
+++ b/streamApp/test.db
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug EPICS database for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 record (stringout, "$(P):cmd")
 {
     field (DTYP, "stream")
@@ -139,4 +160,3 @@ record (waveform, "$(P):spybin")
     field (NELM, "2000")
     field (SCAN, "I/O Intr")
 }
-

--- a/streamApp/test.proto
+++ b/streamApp/test.proto
@@ -1,3 +1,24 @@
+##########################################################################
+# This is an example and debug protocol file for StreamDevice.
+#
+# (C) 2010 Dirk Zimoch (dirk.zimoch@psi.ch)
+#
+# This file is part of StreamDevice.
+#
+# StreamDevice is free software: You can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# StreamDevice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with StreamDevice. If not, see https://www.gnu.org/licenses/.
+#########################################################################/
+
 terminator = LF;
 readtimeout = 10;
 pollperiod = 10;

--- a/streamApp/tests/streamtestlib.tcl
+++ b/streamApp/tests/streamtestlib.tcl
@@ -62,14 +62,17 @@ proc startioc {} {
         puts $fd "streamApp_registerRecordDeviceDriver"
     }
     puts $fd "streamSetLogfile StreamDebug.log"
+    puts $fd "var streamDebug 1"
+    puts $fd "var streamError 1"
     puts $fd "epicsEnvSet STREAM_PROTOCOL_PATH ."
     puts $fd "drvAsynIPPortConfigure device localhost:$port"
+    if [info exists startup] {
+        puts $fd $startup
+    }
     puts $fd "dbLoadRecords test.db"
-    puts $fd $startup
     puts $fd "iocInit"
     puts $fd "dbl"
     puts $fd "dbior stream 2"
-    puts $fd "var streamDebug 1"
     close $fd
     if [info exists streamversion] {
         set ioc [open "|iocsh test.cmd >& $testname.ioclog 2>@stderr" w]

--- a/streamApp/tests/testPercent
+++ b/streamApp/tests/testPercent
@@ -16,7 +16,7 @@ set records {
 
 set protocol {
     Terminator = LF;
-    test1 {out "\%\e%d\e\e\%";}
+    test1 {out "\%\e%d%%\e\e\%";}
 }
 
 set startup {
@@ -28,6 +28,6 @@ set debug 0
 startioc
 
 put DZ:test1 1
-assure "%\0331\033\033%\n"
+assure "%\0331%\033\033%\n"
 
 finish

--- a/streamApp/tests/testStreamBuffer
+++ b/streamApp/tests/testStreamBuffer
@@ -63,7 +63,7 @@ fi
 for o in $O
 do
     g++ -I ../../src $o test.cc -o test.exe
-    test.exe
+    ./test.exe
     if [ $? != 0 ]
     then
         echo -e "\033[31;7mTest failed.\033[0m"


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5283

This updates us to the latest version of stream device (see what's changed at https://github.com/paulscherrerinstitute/StreamDevice/compare/2.8.10...2.8.12).

To test:
* Checkout this branch and run `make` in this directory
* Run the IOC_system tests and confirm they still pass (I just did a few random ones)