### PR TITLE
Correct type in SMDP format converter

### DIFF
--- a/src/SmdpConverter.cc
+++ b/src/SmdpConverter.cc
@@ -40,9 +40,9 @@ const char ESC = '\x07', ESC_ESC = '2';
 
 class SmdpConverter : public StreamFormatConverter
 {
-    int parse (const StreamFormat&, StreamBuffer&, const char*&, bool);
-    bool printPseudo(const StreamFormat&, StreamBuffer&);
-    int scanPseudo(const StreamFormat&, StreamBuffer&, long& cursor);
+    int parse (const StreamFormat&, StreamBuffer&, const char*&, bool) override;
+    bool printPseudo(const StreamFormat&, StreamBuffer&) override;
+    ssize_t scanPseudo(const StreamFormat&, StreamBuffer&, size_t& cursor) override;
 };
 
 int SmdpConverter::
@@ -83,8 +83,8 @@ printPseudo(const StreamFormat& format, StreamBuffer& output)
     return true;
 }
 
-int SmdpConverter::
-scanPseudo(const StreamFormat& format, StreamBuffer& input, long& cursor)
+ssize_t SmdpConverter::
+scanPseudo(const StreamFormat& format, StreamBuffer& input, size_t& cursor)
 {
     int n;
     int start = (format.width < 1) ? 1 : format.width;


### PR DESCRIPTION
At some point it seams StreamFormatConverter changed from having an int scanPseudo method to a ssize_t scanPseudo method. The types have been propogated to the converter for SMDP (Sycon Multi-Drop Protocol, the protocol used by the CP2800), and out an override on their declaration so we can catch if they change again.

For ticket [#6901](https://github.com/ISISComputingGroup/IBEX/issues/6901)