### PR TITLE
Fix spurious "match again" message printed when using @mismatch handler

### DIFF
--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -512,6 +512,7 @@ finishProtocol(ProtocolResult status)
                     debug("reparsing input \"%s\"\n",
                         inputLine.expand()());
                     commandIndex = handler + 1;
+                    previousMismatch = StreamBuffer();
                     if (matchInput())
                     {
                         evalCommand();
@@ -1165,10 +1166,9 @@ readCallback(StreamIoStatus status,
         return 0;
     }
 
-	if (previousMismatch)
+	if (previousMismatch && !(flags & AsyncMode))
 	{
-		error("%s: Match passed again\n",
-            name());
+		error("%s: Match passed again\n", name());
 	}
 
 	previousMismatch = StreamBuffer();


### PR DESCRIPTION
When a @mismatch handler is present you can get messages of the form

2022/01/07 17:39:05.157524 L0 TE:NDW2127:CCD100_01:READING: Match passed again

printed. The original mismatch prior to the mismatch handler being called is supressed, but when the  @mismatch handler completes the above is still printed. This change corrects the behaviour for @mismatch and also supressess generation of output for asynchronous input handlers.

See ISISComputingGroup/IBEX#6440