### PR TITLE
Fix isspace() call for debug build

### DIFF
--- a/src/StreamFormatConverter.cc
+++ b/src/StreamFormatConverter.cc
@@ -523,7 +523,7 @@ scanString(const StreamFormat& fmt, const char* input,
     {
         // normally whitespace ends string
         // but don't end if # flag is present
-        if (!(fmt.flags & alt_flag) && isspace(*input)) break;
+        if (!(fmt.flags & alt_flag) && isspace((unsigned char)*input)) break;
         if (space_left > 1)
         {
             *value++ = *input;


### PR DESCRIPTION
As `input` is a `signed char` it can result in a negative number when cast to int and then cause a debug assert in `isspace` - fixed by casting to `unsigned char` first. Seen in LDENS system tests.